### PR TITLE
Config Server parameter listing corrections

### DIFF
--- a/config-server/_config-server-parameters.html.md.erb
+++ b/config-server/_config-server-parameters.html.md.erb
@@ -1,0 +1,39 @@
+Parameters used to configure the configuration source are part of a JSON object called `git`, as in `{"git": { "uri": "http://example.com/config" } }`. For more information on the purposes of these fields, see the [The Config Server](/spring-cloud-services/config-server/server.html) topic. The parameters are listed below.
+
+| Parameter                                  | Function                                                                                                                                    |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| <code>uri</code>                           | The URI of a repository that can be used as the default configuration source                                                                |
+| <code>label</code>                         | The default "label" that can be used if a request is received without a label                                                               |
+| <code>searchPaths</code>                   | A pattern used to search for configuration-containing subdirectories in the default repository                                              |
+| <code>username</code>                      | The username used to access the default repository (if protected by HTTP Basic authentication)                                              |
+| <code>password</code>                      | The password used to access the default repository (if protected by HTTP Basic authentication)                                              |
+| <code>repos."name"</code>                  | A repository object, containing repository fields                                                                                           |
+| <code>repos."name".pattern</code>          | A pattern for the names of applications that store configuration from this repository (if not supplied, will be <code>"name"</code>)        |
+| <code>repos."name".uri</code>              | The URI (<code>http://</code>, <code>ssh://</code>, or <code>git://</code>) of this repository                                              |
+| <code>repos."name".searchPaths</code>      | A pattern used to search for configuration-containing subdirectories in this repository                                                     |
+| <code>repos."name".username</code>         | The username used to access this repository (if protected by HTTP Basic authentication)                                                     |
+| <code>repos."name".password</code>         | The password used to access this repository (if protected by HTTP Basic authentication)                                                     |
+| <code>repos."name".hostKey</code>          | The host key used by the Config Server to access this repository (if accessing via SSH)                                                     |
+| <code>repos."name".hostKeyAlgorithm</code> | The algorithm of <code>hostKey</code>: one of "ssh-dss", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", and "ecdsa-sha2-nistp521" |
+| <code>repos."name".privateKey</code>       | The private key corresponding to <code>hostKey</code>, with all newline characters replaced by <code>\n</code>                              |
+| <code>proxy.http</code>                    | A proxy object, containing HTTP proxy fields                                                                                                |
+| <code>proxy.http.host</code>               | The HTTP proxy host                                                                                                                         |
+| <code>proxy.http.port</code>               | The HTTP proxy port                                                                                                                         |
+| <code>proxy.http.nonProxyHosts</code>      | The hosts to access outside the HTTP proxy                                                                                                  |
+| <code>proxy.http.username</code>           | The username to use with an authenticated HTTP proxy                                                                                        |
+| <code>proxy.http.password</code>           | The password to use with an authenticated HTTP proxy                                                                                        |
+| <code>proxy.https</code>                   | A proxy object, containing HTTPS proxy fields                                                                                               |
+| <code>proxy.https.host</code>              | The HTTPS proxy host                                                                                                                        |
+| <code>proxy.https.port</code>              | The HTTPS proxy port                                                                                                                        |
+| <code>proxy.https.nonProxyHosts</code>     | The hosts to access outside the HTTPS proxy                                                                                                 |
+| <code>proxy.https.username</code>          | The username to use with an authenticated HTTPS proxy                                                                                       |
+| <code>proxy.https.password</code>          | The password to use with an authenticated HTTPS proxy                                                                                       |
+
+<p class='note'><strong>Important</strong>: Config Server for <a href="https://network.pivotal.io/products/pivotal-cf">Pivotal Cloud Foundry</a> does not support use of a private Git repository accessed via an authenticated proxy server as a configuration source at this time.</p>
+
+Other parameters accepted for the Config Server are listed below.
+
+| Parameter            | Function                                                                                   | Example                          |
+|----------------------|--------------------------------------------------------------------------------------------|----------------------------------|
+| <code>count</code>   | The number of nodes to provision: 1 by default, more for running in high-availability mode | <code>'{"count": 3}'</code>      |
+| <code>upgrade</code> | Whether to upgrade the instance                                                            | <code>'{"upgrade": true}'</code> |

--- a/config-server/_config-server-parameters.html.md.erb
+++ b/config-server/_config-server-parameters.html.md.erb
@@ -1,21 +1,37 @@
-Parameters used to configure the configuration source are part of a JSON object called `git`, as in `{"git": { "uri": "http://example.com/config" } }`. For more information on the purposes of these fields, see the [The Config Server](/spring-cloud-services/config-server/server.html) topic. The parameters are listed below.
+Parameters used to configure configuration sources are part of a JSON object called `git`, as in `{"git": { "uri": "http://example.com/config" } }`. For more information on the purposes of these fields, see the [The Config Server](/spring-cloud-services/config-server/server.html) topic.
+
+The parameters used to configure the Config Server's default configuration source are listed below.
+
+| Parameter                      | Function                                                                                                                                                |
+|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <code>uri</code>               | The URI (<code>http://</code>, <code>https://</code>, or <code>ssh://</code>) of a repository that can be used as the default configuration source      |
+| <code>label</code>             | The default "label" that can be used with the default repository if a request is received without a label                                               |
+| <code>searchPaths</code>       | A pattern used to search for configuration-containing subdirectories in the default repository                                                          |
+| <code>username</code>          | The username used to access the default repository (if protected by HTTP Basic authentication)                                                          |
+| <code>password</code>          | The password used to access the default repository (if protected by HTTP Basic authentication)                                                          |
+| <code>hostKey</code>           | The host key used by the Config Server to access the default repository (if accessing via SSH)                                                          |
+| <code>hostKeyAlgorithm</code>  | The algorithm of <code>hostKey</code>: one of "ssh-dss", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", and "ecdsa-sha2-nistp521"             |
+| <code>privateKey</code>        | The private key corresponding to <code>hostKey</code>, with all newline characters replaced by <code>\n</code>                                          |
+
+The parameters used to configure the Config Server's specific configuration sources are listed below.
 
 | Parameter                                  | Function                                                                                                                                    |
 |--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| <code>uri</code>                           | The URI of a repository that can be used as the default configuration source                                                                |
-| <code>label</code>                         | The default "label" that can be used if a request is received without a label                                                               |
-| <code>searchPaths</code>                   | A pattern used to search for configuration-containing subdirectories in the default repository                                              |
-| <code>username</code>                      | The username used to access the default repository (if protected by HTTP Basic authentication)                                              |
-| <code>password</code>                      | The password used to access the default repository (if protected by HTTP Basic authentication)                                              |
 | <code>repos."name"</code>                  | A repository object, containing repository fields                                                                                           |
 | <code>repos."name".pattern</code>          | A pattern for the names of applications that store configuration from this repository (if not supplied, will be <code>"name"</code>)        |
-| <code>repos."name".uri</code>              | The URI (<code>http://</code>, <code>ssh://</code>, or <code>git://</code>) of this repository                                              |
+| <code>repos."name".uri</code>              | The URI (<code>http://</code>, <code>https://</code>, or <code>ssh://</code>) of this repository                                            |
+| <code>repos."name".label</code>            | The default "label" to use with this repository if a request is received without a label                                                    |
 | <code>repos."name".searchPaths</code>      | A pattern used to search for configuration-containing subdirectories in this repository                                                     |
 | <code>repos."name".username</code>         | The username used to access this repository (if protected by HTTP Basic authentication)                                                     |
 | <code>repos."name".password</code>         | The password used to access this repository (if protected by HTTP Basic authentication)                                                     |
 | <code>repos."name".hostKey</code>          | The host key used by the Config Server to access this repository (if accessing via SSH)                                                     |
 | <code>repos."name".hostKeyAlgorithm</code> | The algorithm of <code>hostKey</code>: one of "ssh-dss", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", and "ecdsa-sha2-nistp521" |
 | <code>repos."name".privateKey</code>       | The private key corresponding to <code>hostKey</code>, with all newline characters replaced by <code>\n</code>                              |
+
+The parameters used to configure any proxy settings for the Config Server are listed below.
+
+| Parameter                                  | Function                                                                                                                                    |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | <code>proxy.http</code>                    | A proxy object, containing HTTP proxy fields                                                                                                |
 | <code>proxy.http.host</code>               | The HTTP proxy host                                                                                                                         |
 | <code>proxy.http.port</code>               | The HTTP proxy port                                                                                                                         |

--- a/config-server/creating-an-instance.html.md.erb
+++ b/config-server/creating-an-instance.html.md.erb
@@ -46,45 +46,7 @@ standard       Standard Plan   free
 
 Create the service instance using `cf create-service`, using the `-c` flag to provide a JSON object that specifies configuration parameters.
 
-Parameters used to configure the configuration source are part of a JSON object called `git`, as in `{"git": { "uri": "http://example.com/config" } }`. For more information on the purposes of these fields, see the [The Config Server](/spring-cloud-services/config-server/server.html) topic. The parameters are listed below.
-
-| Parameter                                  | Function                                                                                                                                    |
-|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| <code>uri</code>                           | The URI of a repository that can be used as the default configuration source                                                                |
-| <code>label</code>                         | The default "label" that can be used if a request is received without a label                                                               |
-| <code>searchPaths</code>                   | A pattern used to search for configuration-containing subdirectories in the default repository                                              |
-| <code>username</code>                      | The username used to access the default repository (if protected by HTTP Basic authentication)                                              |
-| <code>password</code>                      | The password used to access the default repository (if protected by HTTP Basic authentication)                                              |
-| <code>repos."name"</code>                  | A repository object, containing repository fields                                                                                           |
-| <code>repos."name".pattern</code>          | A pattern for the names of applications that store configuration from this repository (if not supplied, will be <code>"name"</code>)        |
-| <code>repos."name".uri</code>              | The URI (<code>http://</code>, <code>ssh://</code>, or <code>git://</code>) of this repository                                              |
-| <code>repos."name".searchPaths</code>      | A pattern used to search for configuration-containing subdirectories in this repository                                                     |
-| <code>repos."name".username</code>         | The username used to access this repository (if protected by HTTP Basic authentication)                                                     |
-| <code>repos."name".password</code>         | The password used to access this repository (if protected by HTTP Basic authentication)                                                     |
-| <code>repos."name".hostKey</code>          | The host key used by the Config Server to access this repository (if accessing via SSH)                                                     |
-| <code>repos."name".hostKeyAlgorithm</code> | The algorithm of <code>hostKey</code>: one of "ssh-dss", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", and "ecdsa-sha2-nistp521" |
-| <code>repos."name".privateKey</code>       | The private key corresponding to <code>hostKey</code>, with all newline characters replaced by <code>\n</code>                              |
-| <code>proxy.http</code>                    | A proxy object, containing HTTP proxy fields                                                                                                |
-| <code>proxy.http.host</code>               | The HTTP proxy host                                                                                                                         |
-| <code>proxy.http.port</code>               | The HTTP proxy port                                                                                                                         |
-| <code>proxy.http.nonProxyHosts</code>      | The hosts to access outside the HTTP proxy                                                                                                  |
-| <code>proxy.http.username</code>           | The username to use with an authenticated HTTP proxy                                                                                        |
-| <code>proxy.http.password</code>           | The password to use with an authenticated HTTP proxy                                                                                        |
-| <code>proxy.https</code>                   | A proxy object, containing HTTPS proxy fields                                                                                               |
-| <code>proxy.https.host</code>              | The HTTPS proxy host                                                                                                                        |
-| <code>proxy.https.port</code>              | The HTTPS proxy port                                                                                                                        |
-| <code>proxy.https.nonProxyHosts</code>     | The hosts to access outside the HTTPS proxy                                                                                                 |
-| <code>proxy.https.username</code>          | The username to use with an authenticated HTTPS proxy                                                                                       |
-| <code>proxy.https.password</code>          | The password to use with an authenticated HTTPS proxy                                                                                       |
-
-<p class='note'><strong>Important</strong>: Config Server for <a href="https://network.pivotal.io/products/pivotal-cf">Pivotal Cloud Foundry</a> does not support use of a private Git repository accessed via an authenticated proxy server as a configuration source at this time.</p>
-
-Other parameters accepted for the Config Server are listed below.
-
-| Parameter            | Function                                                                                   | Example                          |
-|----------------------|--------------------------------------------------------------------------------------------|----------------------------------|
-| <code>count</code>   | The number of nodes to provision: 1 by default, more for running in high-availability mode | <code>'{"count": 3}'</code>      |
-| <code>upgrade</code> | Whether to upgrade the instance                                                            | <code>'{"upgrade": true}'</code> |
+<%= partial 'config-server-parameters' %>
 
 To create an instance, specifying settings for the configuration sources and that three nodes should be provisioned:
 

--- a/config-server/updating-an-instance.html.md.erb
+++ b/config-server/updating-an-instance.html.md.erb
@@ -7,45 +7,7 @@ owner: Spring Cloud Services
 
 You can update settings on a Config Server service instance using the cf Command Line Interface tool. The `cf update-service` command can be given a `-c` flag with a JSON object containing parameters used to configure the service instance.
 
-Parameters used to configure the configuration source are part of a JSON object called `git`, as in `{"git": { "uri": "http://example.com/config" } }`. For more information on the purposes of these fields, see the [The Config Server](/spring-cloud-services/config-server/server.html) topic. The parameters are listed below.
-
-| Parameter                                  | Function                                                                                                                                    |
-|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| <code>uri</code>                           | The URI of a repository that can be used as the default configuration source                                                                |
-| <code>label</code>                         | The default "label" that can be used if a request is received without a label                                                               |
-| <code>searchPaths</code>                   | A pattern used to search for configuration-containing subdirectories in the default repository                                              |
-| <code>username</code>                      | The username used to access the default repository (if protected by HTTP Basic authentication)                                              |
-| <code>password</code>                      | The password used to access the default repository (if protected by HTTP Basic authentication)                                              |
-| <code>repos."name"</code>                  | A repository object, containing repository fields                                                                                           |
-| <code>repos."name".pattern</code>          | A pattern for the names of applications that store configuration from this repository (if not supplied, will be <code>"name"</code>)        |
-| <code>repos."name".uri</code>              | The URI (<code>http://</code>, <code>ssh://</code>, or <code>git://</code>) of this repository                                              |
-| <code>repos."name".searchPaths</code>      | A pattern used to search for configuration-containing subdirectories in this repository                                                     |
-| <code>repos."name".username</code>         | The username used to access this repository (if protected by HTTP Basic authentication)                                                     |
-| <code>repos."name".password</code>         | The password used to access this repository (if protected by HTTP Basic authentication)                                                     |
-| <code>repos."name".hostKey</code>          | The host key used by the Config Server to access this repository (if accessing via SSH)                                                     |
-| <code>repos."name".hostKeyAlgorithm</code> | The algorithm of <code>hostKey</code>: one of "ssh-dss", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", and "ecdsa-sha2-nistp521" |
-| <code>repos."name".privateKey</code>       | The private key corresponding to <code>hostKey</code>, with all newline characters replaced by <code>\n</code>                              |
-| <code>proxy.http</code>                    | A proxy object, containing HTTP proxy fields                                                                                                |
-| <code>proxy.http.host</code>               | The HTTP proxy host                                                                                                                         |
-| <code>proxy.http.port</code>               | The HTTP proxy port                                                                                                                         |
-| <code>proxy.http.nonProxyHosts</code>      | The hosts to access outside the HTTP proxy                                                                                                  |
-| <code>proxy.http.username</code>           | The username to use with an authenticated HTTP proxy                                                                                        |
-| <code>proxy.http.password</code>           | The password to use with an authenticated HTTP proxy                                                                                        |
-| <code>proxy.https</code>                   | A proxy object, containing HTTPS proxy fields                                                                                               |
-| <code>proxy.https.host</code>              | The HTTPS proxy host                                                                                                                        |
-| <code>proxy.https.port</code>              | The HTTPS proxy port                                                                                                                        |
-| <code>proxy.https.nonProxyHosts</code>     | The hosts to access outside the HTTPS proxy                                                                                                 |
-| <code>proxy.https.username</code>          | The username to use with an authenticated HTTPS proxy                                                                                       |
-| <code>proxy.https.password</code>          | The password to use with an authenticated HTTPS proxy                                                                                       |
-
-<p class='note'><strong>Important</strong>: Config Server for <a href="https://network.pivotal.io/products/pivotal-cf">Pivotal Cloud Foundry</a> does not support use of a private Git repository accessed via an authenticated proxy server as a configuration source at this time.</p>
-
-Other parameters accepted for the Config Server are listed below.
-
-| Parameter            | Function                                                                                   | Example                          |
-|----------------------|--------------------------------------------------------------------------------------------|----------------------------------|
-| <code>count</code>   | The number of nodes to provision: 1 by default, more for running in high-availability mode | <code>'{"count": 3}'</code>      |
-| <code>upgrade</code> | Whether to upgrade the instance                                                            | <code>'{"upgrade": true}'</code> |
+<%= partial 'config-server-parameters' %>
 
 To update a Config Server service instance's settings, target the org and space of the service instance:
 


### PR DESCRIPTION
This also moves the parameter list into a partial and splits up the original configuration source settings table into three tables.

[Pivotal Tracker story](https://www.pivotaltracker.com/story/show/127633567)

cc @csterwa