### PR TITLE
Update links from javadocs to Spring core docs

### DIFF
--- a/common/config-server/background-information.html.md.erb
+++ b/common/config-server/background-information.html.md.erb
@@ -51,7 +51,7 @@ A path includes an _application_, a _profile_, and optionally a _label_.
 
 * **Application**: The name of the application. In a Spring application, this will be derived from `spring.application.name` or `spring.cloud.config.name`.
 
-* **Profile**: The name of a profile, or a comma-separated list of profile names. The Config Server's concept of a "profile" corresponds directly to that of the <a href="http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/Profile.html">Spring Profile</a>.
+* **Profile**: The name of a profile, or a comma-separated list of profile names. The Config Server's concept of a "profile" corresponds directly to that of the <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-definition-profiles">Spring Profile</a>.
 
 * **Label**: The name of a version marker in the configuration source (the repository). This might be a branch name, a tag name, or a Git commit hash. The value given to the Config Server as a default label (the setting of `git.label`; see the table of the Config Server's [general configuration parameters](./configuring-with-git.html#general-configuration)) can be overridden in a client application by setting the `spring.cloud.config.label` property.
 
@@ -95,7 +95,7 @@ As shown in the above example, the Config Server may include multiple values for
 
 #### Spring Client Applications
 
-A Spring application can use a Config Server as a <a href="http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/PropertySource.html">property source</a>. Properties from a Config Server will override those defined locally (e.g. via an `application.yml` in the classpath).
+A Spring application can use a Config Server as a <a href="https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-property-source-abstraction">property source</a>. Properties from a Config Server will override those defined locally (e.g. via an `application.yml` in the classpath).
 
 The application requests properties from the Config Server using a path such as ```/{application}/{profile}/[{label}]``` (see the <a href="#request-paths">Request Paths</a> section). It will derive values for these three parameters from the following properties:
 


### PR DESCRIPTION
Copied from Slack:

```
Dylan Roberts [2:44 PM]
@bklein Hey Ben. Since you asked for feedback on the SCS docs, I've got one for you.
In the config server docs, background information section: http://docs.pivotal.io/spring-cloud-services/1-4/common/config-server/background-information.html
under Request Paths header (1/3 down the page linked above)...
This line appears `Profile: The name of a profile, or a comma-separated list of profile names. The Config Server's concept of a "profile" corresponds directly to that of the Spring Profile`
The words `Spring Profile` are linked to the javadoc of the `@Profile` annotation
I think it might be more usefule to link to the Spring Framework core docs, explaining what a profile is and what it's for.
Maybe here: https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-definition-profiles
Just a thought!

Dylan Roberts [2:59 PM]
@bklein One more similar one, on the same page. Near the bottom under the Spring Client Applications section...
There's a reference to `property source` which links to the `@PropertySource` javadocs
but the Spring core docs have a great higher level explaination of property sources here: https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-property-source-abstraction```