### PR TITLE
[#155784574] Fixed client dependencies for 1.4.x to use Spring Cloud …

### DIFF
--- a/common/_general-dependencies.html.md.erb
+++ b/common/_general-dependencies.html.md.erb
@@ -2,13 +2,13 @@
 
 To work with Spring Cloud Services service instances, your client application must include the `spring-cloud-services-dependencies` and `spring-cloud-dependencies` BOMs. Unless you are using the `spring-boot-starter-parent` or Spring Boot Gradle plugin, you must also specify the `spring-boot-dependencies` BOM as a dependency. See below for compatible Spring Boot and Spring Cloud versions to use with a given Spring Cloud Services release.
 
-| Spring Cloud Services | Spring Boot  | Spring Cloud           |
-|-----------------------|--------------|------------------------|
-| 1.0.x                 | 1.2.x        | Angel.x                |
-| 1.1.x                 | 1.3.x--1.4.x | Brixton.x              |
-| 1.2.x                 | 1.3.x--1.4.x | Brixton.x              |
-| 1.3.x                 | 1.3.x--1.4.x | Camden.x               |
-| 1.4.x *               | 1.5.x        | Dalston.x--Edgware.SR1 |
+| Spring Cloud Services | Spring Boot  | Spring Cloud  |
+|-----------------------|--------------|---------------|
+| 1.0.x                 | 1.2.x        | Angel.x       |
+| 1.1.x                 | 1.3.x--1.4.x | Brixton.x     |
+| 1.2.x                 | 1.3.x--1.4.x | Brixton.x     |
+| 1.3.x                 | 1.3.x--1.4.x | Camden.x      |
+| 1.4.x *               | 1.5.x        | Dalston.x     |
 
 <p class='note'><strong>Important</strong>: Spring Cloud Services is affected by an <a href="https://github.com/spring-projects/spring-boot/issues/9079">issue in Spring Boot version 1.5.3</a> and is not compatible with that version. To be compatible with Spring Cloud Services 1.4.0, client applications should use Spring Boot versions 1.5.0--1.5.2 or 1.5.4 and later.</p>
 <p class='note'><strong>Note</strong>: An application using Spring Cloud Services 1.3.x dependencies only requires an update to 1.4.x dependencies if using the Config Server support for HashiCorp Vault.</p>
@@ -28,14 +28,14 @@ If using Maven, include in `pom.xml`:
         <dependency>
             <groupId>io.pivotal.spring.cloud</groupId>
             <artifactId>spring-cloud-services-dependencies</artifactId>
-            <version>1.6.1.RELEASE</version>
+            <version>1.5.0.RELEASE</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-dependencies</artifactId>
-            <version>Edgware.SR1</version>
+            <version>Dalston.SR5</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -83,8 +83,8 @@ apply plugin: "io.spring.dependency-management"
 
 dependencyManagement {
     imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:Edgware.SR1"
-        mavenBom "io.pivotal.spring.cloud:spring-cloud-services-dependencies:1.6.1.RELEASE"
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:Dalston.SR5"
+        mavenBom "io.pivotal.spring.cloud:spring-cloud-services-dependencies:1.5.0.RELEASE"
     }
 }
 


### PR DESCRIPTION
…Dalston and proper SCS client dependencies 1.5.0.RELEASE versions. Also updated the table to only use Dalston with 1.4.x.