### PR TITLE
Update UAA credentials in Security Overview

### DIFF
--- a/common/security-overview.html.md.erb
+++ b/common/security-overview.html.md.erb
@@ -167,14 +167,14 @@ If the Operator has configured the Spring Cloud Services tile to [secure service
 
 <dl>
 <dd><strong>Identity Zone</strong>: UAA</dd>
-<dd><strong>Grant Type</strong>: Authorization Code</dd>
+<dd><strong>Grant Type</strong>: Authorization Code, Client Credentials</dd>
 <dd><strong>Redirect URI</strong>: https://spring-cloud-broker.domain.com/dashboard/login</dd>
-<dd><strong>Scopes</strong>: <code>cloud_controller.read</code>, <code>cloud_controller.write</code>, <code>cloud_controller_service_permissions.read</code>, <code>openid</code></dd>
-<dd><strong>Authorities</strong>: <code>uaa.resource</code></dd>
+<dd><strong>Scopes</strong>: <code>cloud_controller.read</code>, <code>cloud_controller.admin</code>, <code>cloud_controller_service_permissions.read</code>, <code>openid</code></dd>
+<dd><strong>Authorities</strong>: <code>uaa.resource</code>, <code>credhub.read</code>, <code>credhub.write</code></dd>
 <dd><strong>Token expiry</strong>: default (12 hours)</dd>
 </dl>
 
-This client is used for SSO with UAA. The scopes allow the SB to access the Cloud Controller API on the user's behalf, and are auto-approved. The ```uaa.resource``` authority allows the SB to access the token verification endpoints on UAA. The client ID and client secret are made available to the SB via environment variables, which are set at installation time and are stored in encrypted form in the CC DB.
+This client is used for SSO with UAA. The scopes allow the SB to access the Cloud Controller API on the user's behalf, and are auto-approved. The ```uaa.resource``` authority allows the SB to access the token verification endpoints on UAA. The ```credhub.read``` and ```credhub.write``` authorities are only granted if the operator has configured the Spring Cloud Services tile to [secure service instance credentials](http://docs.pivotal.io/pivotalcf/2-0/opsguide/secure-si-creds.html) using CredHub, and allow the SB to store service binding credentials in CredHub securely. The SB's client ID and client secret are made available to the SB via environment variables, which are set at installation time and are stored in encrypted form in the CC DB.
 
 ### <a id="spring-cloud-broker-worker"></a>Spring Cloud Service Broker Worker
 
@@ -206,7 +206,7 @@ The Worker uses a p-rabbitmq service instance to receive messages from the SB. T
 
 **The Cloud Controller**
 
-The Worker communicates to the CC via HTTPS to carry out management tasks for service instance backing apps. All backing applications reside in the "p-spring-cloud-services" org, "instances" space. The Worker uses its own [user credentials](#worker-user-p-spring-cloud-services) to obtain a token for accessing the CC API and acts as a Space Developer in the "instances" space.
+The Worker communicates to the CC via HTTPS to carry out management tasks for service instance backing apps. All backing applications reside in the "p-spring-cloud-services" org, "instances" space. The Worker uses its own [client credentials](#worker-oauth-client-uaa) to obtain a token for accessing the CC API.
 
 The URI to the CC is set at installation time in the Worker's environment variables, under the name ```CF_TARGET```, which is set at installation time and can only be modified by the Operator.
 
@@ -232,14 +232,14 @@ After CredHub generates the credential and passes it to the Worker, the Worker d
 
 #### OAuth Clients
 
-**p-spring-cloud-services-worker**
+<a id="worker-oauth-client-uaa"></a>**p-spring-cloud-services-worker**
 
 <dl>
 <dd><strong>Identity Zone</strong>: UAA</dd>
 <dd><strong>Grant Type</strong>: Client Credentials</dd>
 <dd><strong>Redirect URI</strong>: https://spring-cloud-broker.domain.com/dashboard/login</dd>
-<dd><strong>Scopes</strong>: <code>cloud_controller.read</code>, <code>cloud_controller_service_permissions.read</code>, <code>openid</code></dd>
-<dd><strong>Authorities</strong>: <code>clients.write</code></dd>
+<dd><strong>Scopes</strong>: <code>cloud_controller.read</code>, <code>cloud_controller.admin</code>, <code>cloud_controller_service_permissions.read</code>, <code>openid</code></dd>
+<dd><strong>Authorities</strong>: <code>cloud_controller.read</code>, <code>cloud_controller.admin</code>, <code>cloud_controller_service_permissions.read</code>, <code>clients.read</code>, <code>clients.write</code>, <code>credhub.read</code>, <code>credhub.write</code></dd>
 <dd><strong>Token expiry</strong>: default (12 hours)</dd>
 </dl>
 
@@ -247,7 +247,7 @@ This client is used to create and delete SSO clients for each Service Registry a
 
 While arbitrary clients cannot be created via this client, this client is able to delete any client in the UAA Identity Zone due to the ```clients.write``` authority.
 
-The client ID and client secret are made available to the SB via environment variables, which are set at installation time and are stored in encrypted form in the CC DB. The credentials are only visible to the Operator.
+The ```credhub.read``` and ```credhub.write``` authorities are only granted if the operator has configured the Spring Cloud Services tile to [secure service instance credentials](http://docs.pivotal.io/pivotalcf/2-0/opsguide/secure-si-creds.html) using CredHub, and allow the Worker to store service backing app credentials in CredHub securely. The Worker's client ID and client secret are made available to the Worker via environment variables, which are set at installation time and are stored in encrypted form in the CC DB. The credentials are only visible to the Operator.
 
 <a id="worker-oauth-client-scs"></a>**p-spring-cloud-services-worker**
 
@@ -266,7 +266,7 @@ The client ID and client secret are the same as the corresponding client in the 
 
 <a id="worker-user-p-spring-cloud-services"></a>**p-spring-cloud-services**
 
-This user is a Space Developer in the "p-spring-cloud-services" org, "instances" space. The user has no other roles. The username and password are made available to the Worker via environment variables, which are set at installation time and are stored in encrypted form in the CC DB. The credentials are only visible to the Operator.
+In previous versions of Spring Cloud Services, this user was a Space Developer in the "p-spring-cloud-services" org, "instances" space, and was used for authentication of the Worker with CC. Client credentials are now used for this purpose, making this user redundant. On upgrade to a version of Spring Cloud Services which uses client credentials, this user is deleted if it exists.
 
 ### <a id="config-server-service-instances"></a>Config Server Service Instances
 
@@ -500,7 +500,7 @@ The Eureka server enforces ownership of Instance Records to prevent binding cred
 
 <a id="service-registry-application-name-ownership"></a>*Application Name Ownership*
 
-The Eureka server enforces the ownership of Eureka Application Names within a cluster. For a given Eureka cluster, possibly comprised of peers spanning multiple PCF installations, only one service instance in a PCF installation may register instances with a particular Eureka Application Name. This is enforced to ensure that CF Applications in other spaces cannot register and draw traffic away from a given application, as a form of [man-in-the-middle attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack). However, a service instance in a different PCF installation can still register the same Eureka Application Name. This is allowed so that CF Applications in other PCF installations can be used for failover, in case all instances with a given Eureka Application Name in a particular PCF are down. 
+The Eureka server enforces the ownership of Eureka Application Names within a cluster. For a given Eureka cluster, possibly comprised of peers spanning multiple PCF installations, only one service instance in a PCF installation may register instances with a particular Eureka Application Name. This is enforced to ensure that CF Applications in other spaces cannot register and draw traffic away from a given application, as a form of [man-in-the-middle attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack). However, a service instance in a different PCF installation can still register the same Eureka Application Name. This is allowed so that CF Applications in other PCF installations can be used for failover, in case all instances with a given Eureka Application Name in a particular PCF are down.
 
 To enforce Eureka Application Name ownership, the URI of the Eureka server that registers the Instance Record is recorded under the metadata key ```registrar_uri```. A portion of this URI is used to identity the PCF installation that hosts the Eureka server. When a CF Application registers with the server by submitting an Instance Record, all other Instance Records with the same Eureka Application Name are inspected. If an Instance Record already exists in the same PCF installation as the server receiving the registration request, and this Instance Record's ```registrar_uri``` does not match the server's, the registration request is rejected.
 


### PR DESCRIPTION
We now use client credentials rather than user credentials to
authenticate with CC.

connected to pivotal-cf/docs-spring-cloud-services#146