### PR TITLE
example curl command is broken, needs ""

### DIFF
--- a/common/config-server/_oauth_token.html.md.erb
+++ b/common/config-server/_oauth_token.html.md.erb
@@ -2,6 +2,6 @@ When the Config Server has been configured to encrypt values, you can make a POS
 
 <pre>
 <code>
-curl -H 'Authorization: bearer TOKEN_STRING' http://SERVER/encrypt -d 'Value to be encrypted'
+curl -H "Authorization: bearer TOKEN_STRING" http://SERVER/encrypt -d 'Value to be encrypted'
 </code>
 </pre>


### PR DESCRIPTION
curl -H 'Authorization: $(cf oauth-token)' will not work, and needs to
be curl -H "Authorization: $(cf oauth-token)"