### PR TITLE
URL Cleanup

### DIFF
--- a/common/cf-cli-plugin.html.md.erb
+++ b/common/cf-cli-plugin.html.md.erb
@@ -7,7 +7,7 @@ owner: Spring Cloud Services
 
 The Spring Cloud Services plugin for the Cloud Foundry Command Line Interface tool (cf CLI) adds commands for interacting with Spring Cloud Services service instances. It provides easy access to functionality relating to the Config Server and Service Registry; for example, it can be used to send values to a Config Server service instance for encryption or to list all applications registered with a Service Registry service instance.
 
-The Spring Cloud Services cf CLI plugin is open-source software released under the [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.html) license. From the plugin's [homepage on GitHub](https://github.com/pivotal-cf/spring-cloud-services-cli-plugin), you can raise issues or submit contributions for consideration by the plugin's authors.
+The Spring Cloud Services cf CLI plugin is open-source software released under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html) license. From the plugin's [homepage on GitHub](https://github.com/pivotal-cf/spring-cloud-services-cli-plugin), you can raise issues or submit contributions for consideration by the plugin's authors.
 
 ## Installation
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0.html with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).