### PR TITLE
URL Cleanup

### DIFF
--- a/common/config-server/configuring-with-git.html.md.erb
+++ b/common/config-server/configuring-with-git.html.md.erb
@@ -15,7 +15,7 @@ See below for information about configuring a Config Server service instance to 
 
 ## <a id="general-configuration"></a>General Configuration
 
-Parameters used to configure configuration sources are part of a JSON object called `git`, as in `{"git": { "uri": "http://example.com/config" } }`. General parameters used to configure the Config Server's default configuration source are listed below.
+Parameters used to configure configuration sources are part of a JSON object called `git`, as in `{"git": { "uri": "https://example.com/config" } }`. General parameters used to configure the Config Server's default configuration source are listed below.
 
 | Parameter                      | Function                                                                                                                          |
 |--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|

--- a/common/config-server/connectors.html.md.erb
+++ b/common/config-server/connectors.html.md.erb
@@ -5,7 +5,7 @@ owner: Spring Cloud Services
 
 <strong><%= modified_date %></strong>
 
-To connect client apps to the Config Server, Spring Cloud Services uses [Spring Cloud Connectors](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html), including the [Spring Cloud Cloud Foundry Connector](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html), which discovers services bound to apps running in Cloud Foundry.
+To connect client apps to the Config Server, Spring Cloud Services uses [Spring Cloud Connectors](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html), including the [Spring Cloud Cloud Foundry Connector](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html), which discovers services bound to apps running in Cloud Foundry.
 
 ## <a id="application-configuration"></a>Application Configuration
 
@@ -53,6 +53,6 @@ endpoints:
 
 For more information about Spring Cloud Connectors, see the following:
 
-* [Spring Cloud Cloud Foundry Connector documentation](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html)
-* [Spring Cloud Connectors documentation](http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html)
+* [Spring Cloud Cloud Foundry Connector documentation](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html)
+* [Spring Cloud Connectors documentation](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html)
 * [Spring Cloud Connectors for Spring Cloud Services on Pivotal Cloud Foundry](https://github.com/pivotal-cf/spring-cloud-services-connector)

--- a/common/config-server/writing-client-applications.html.md.erb
+++ b/common/config-server/writing-client-applications.html.md.erb
@@ -9,7 +9,7 @@ _Refer to the <a href="https://github.com/spring-cloud-services-samples/cook/tre
 
 To use a Spring Boot app as a client for a Config Server instance, you must add the dependencies listed in <a href="../client-dependencies.html">Client Dependencies</a> to your app's build file. Be sure to include the dependencies for <a href="../client-dependencies.html#config-server">Config Server</a> as well.
 
-<p class='note'><strong>Important</strong>: Because of a dependency on <a href="http://projects.spring.io/spring-security/">Spring Security</a>, the Spring Cloud&reg; Config Client starter will by default cause all app endpoints to be protected by HTTP Basic authentication. If you wish to disable this, please see <a href="#disable-http-basic-auth">Disable HTTP Basic Authentication</a> below.</p>
+<p class='note'><strong>Important</strong>: Because of a dependency on <a href="https://projects.spring.io/spring-security/">Spring Security</a>, the Spring Cloud&reg; Config Client starter will by default cause all app endpoints to be protected by HTTP Basic authentication. If you wish to disable this, please see <a href="#disable-http-basic-auth">Disable HTTP Basic Authentication</a> below.</p>
 
 <% if vars.product_name == 'PCF' %>
  <%= partial vars.scs_cs_self_signed_ssl %>
@@ -29,7 +29,7 @@ spring:
 
 This app will use a path with the application name `cook`, so the Config Server will look in its configuration source for files whose names begin with `cook`, and return configuration properties from those files.
 
-Now you can (for example) inject a configuration property value using the <a href="http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Value.html">`@Value`</a> annotation. <a href="https://github.com/spring-cloud-services-samples/cook/blob/master/src/main/java/cook/Menu.java">The Menu class</a> reads the value of `special` from the `cook.special` configuration property.
+Now you can (for example) inject a configuration property value using the <a href="https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Value.html">`@Value`</a> annotation. <a href="https://github.com/spring-cloud-services-samples/cook/blob/master/src/main/java/cook/Menu.java">The Menu class</a> reads the value of `special` from the `cook.special` configuration property.
 
 ```java
 @RefreshScope
@@ -122,7 +122,7 @@ When the Config Server returns multiple values for a configuration property, the
 
 ## <a id="view-client-application-configuration"></a>View Client Application Configuration
 
-<a href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready">Spring Boot Actuator</a> adds an `env` endpoint to the app and maps it to `/actuator/env`. This endpoint displays the app's profiles and property sources from the Spring ```ConfigurableEnvironment```. (See ["Endpoints"](http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) in the "Spring Boot Actuator" section of the Spring Boot Reference Guide.) In the case of an app which is bound to a Config Server service instance, `env` will display properties provided by the instance.
+<a href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready">Spring Boot Actuator</a> adds an `env` endpoint to the app and maps it to `/actuator/env`. This endpoint displays the app's profiles and property sources from the Spring ```ConfigurableEnvironment```. (See ["Endpoints"](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) in the "Spring Boot Actuator" section of the Spring Boot Reference Guide.) In the case of an app which is bound to a Config Server service instance, `env` will display properties provided by the instance.
 
 To use Actuator, you must add the `spring-boot-starter-actuator` dependency to your project. If using Maven, <a href="https://github.com/spring-cloud-services-samples/cook/blob/master/pom.xml#L56-L59">add to `pom.xml`</a>:
 
@@ -142,7 +142,7 @@ compile("org.springframework.boot:spring-boot-starter-actuator")
 You can now visit `/actuator/env` to see the application environment's properties (the following shows an excerpt of an example response):
 
 <pre class="terminal">
-$ curl http://cookie.apps.wise.com/actuator/env
+$ curl https://cookie.apps.wise.com/actuator/env
 {
   "activeProfiles": [
   "development",
@@ -193,7 +193,7 @@ public class Menu {
 This means that after you change values in the configuration source Git repository, you can update the `special` on the `CookController` class's `menu` by creating a refresh event for the app:
 
 <pre class="terminal">
-$ curl http://cookie.apps.wise.com/restaurant
+$ curl https://cookie.apps.wise.com/restaurant
 Today's special is: Pickled Cactus
 
 $ git commit -am "new special"
@@ -202,10 +202,10 @@ $ git commit -am "new special"
 
 $ git push
 
-$ curl -X POST -d {} -H "Content-Type: application/json" http://cookie.apps.wise.com/actuator/refresh
+$ curl -X POST -d {} -H "Content-Type: application/json" https://cookie.apps.wise.com/actuator/refresh
 ["cook.special"]
 
-$ curl http://cookie.apps.wise.com/restaurant
+$ curl https://cookie.apps.wise.com/restaurant
 Today's special is: Birdfeather Tea
 </pre>
 
@@ -361,7 +361,7 @@ ttl                  997
 
 ## <a id="disable-http-basic-auth"></a>Disable HTTP Basic Authentication
 
-The Spring Cloud Config Client starter has a dependency on <a href="http://projects.spring.io/spring-security/">Spring Security</a>. Unless your app has other security configuration, this will cause all app endpoints to be protected by HTTP Basic authentication.
+The Spring Cloud Config Client starter has a dependency on <a href="https://projects.spring.io/spring-security/">Spring Security</a>. Unless your app has other security configuration, this will cause all app endpoints to be protected by HTTP Basic authentication.
 
 If you do not yet want to address application security, you may turn off Basic authentication using [a class that extends Spring Security's `WebSecurityConfigurerAdapter` and is annotated with the Spring `@Configuration` annotation](https://github.com/spring-cloud-services-samples/cook/blob/master/src/main/java/cook/SecurityConfiguration.java). The sample app disables all default security for the `development` profile only, using the `@Profile` annotation:
 
@@ -382,4 +382,4 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 }
 ```
 
-For more information, see ["Security" in the Spring Boot Reference Guide](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-security).
+For more information, see ["Security" in the Spring Boot Reference Guide](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-security).

--- a/installation.html.md.erb
+++ b/installation.html.md.erb
@@ -33,7 +33,7 @@ Ensure that you have or have completed all items listed in <a href="common/index
     Select the availability zones for the tile to use. In the **Network** section, select the network used by Pivotal Application Service (or Elastic Runtime). When finished, click **Save**.
 
 <%# removing for now
-1. If the **Stemcell** tab is highlighted in orange, click it. Download the correct stemcell from [Pivotal Network](http://network.pivotal.io) and click **Import Stemcell** to import it.
+1. If the **Stemcell** tab is highlighted in orange, click it. Download the correct stemcell from [Pivotal Network](https://network.pivotal.io) and click **Import Stemcell** to import it.
 
     installation/stemcell.png
 %>

--- a/service-instances.html.md.erb
+++ b/service-instances.html.md.erb
@@ -17,7 +17,7 @@ A service instance is assigned a GUID at provision time. Backing apps for servic
 
 **Config Server**
 
-* config-[GUID]: A [Spring Cloud Config](http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html) server app.
+* config-[GUID]: A [Spring Cloud Config](https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html) server app.
 
 <%= image_tag("/spring-cloud-services/images/operator-information/ops1.png") %>
 
@@ -76,7 +76,7 @@ Look for the backing app named as described above, with the prefix specific to t
 <a id="get-service-instance-information"></a>
 #### Get Service Instance Information
 
-Each backing app for a service instance has the [Spring Boot Actuator](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready) `info` endpoint enabled and accessible at `/actuator/info`. You can obtain version and other information about a service instance by accessing this endpoint.
+Each backing app for a service instance has the [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready) `info` endpoint enabled and accessible at `/actuator/info`. You can obtain version and other information about a service instance by accessing this endpoint.
 
 Locate a backing app for a service instance as described in the [Access Service Instance Backing Applications in Apps Manager](#access-service-instance-backing-applications-in-apps-manager) section. In Apps Manager, on the page for the backing app, click the **Route** tab and copy the route for the app.
 
@@ -261,7 +261,7 @@ If the backing app is not running properly then detailed health information will
 
 ### <a id="access-actuator-endpoints"></a>Access Actuator Endpoints
 
-Service instance backing apps use [Spring Boot Actuator](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready). Actuator adds a number of endpoints to these apps; some of the added endpoints are summarized below.
+Service instance backing apps use [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready). Actuator adds a number of endpoints to these apps; some of the added endpoints are summarized below.
 
 | Endpoint ID           | Endpoint Function                                                                    |
 |-----------------------|--------------------------------------------------------------------------------------|
@@ -271,7 +271,7 @@ Service instance backing apps use [Spring Boot Actuator](http://docs.spring.io/s
 | <code>mappings</code> | Displays list of <code>@RequestMapping</code> paths in the app                       |
 | <code>shutdown</code> | Gracefully shuts down the app (disabled in Spring Cloud Services)                    |
 
-See the <a href="http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-endpoints">Endpoints</a> section of the Actuator documentation for the full list of endpoints.
+See the <a href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-endpoints">Endpoints</a> section of the Actuator documentation for the full list of endpoints.
 
 #### Invoking Actuator Endpoints
 

--- a/tile-configuration.html.md.erb
+++ b/tile-configuration.html.md.erb
@@ -77,7 +77,7 @@ In the **Persistence store service** and **Persistence store service plan** fiel
 
 Spring Cloud Services can store its service instances' credentials in the Runtime CredHub. You can enable this behavior by selecting the **Secure service instance credentials** checkbox.
 
-<p class="note"><strong>Important: </strong> To use CredHub with Spring Cloud Services, you must be using Pivotal Application Service (PAS) 2.0 or later, have <a href="http://docs.pivotal.io/pivotalcf/opsguide/secure-si-creds.html">configured the Runtime CredHub</a>, and have at least one CredHub job instance configured in the PAS tile's Resource Config settings tab.</p>
+<p class="note"><strong>Important: </strong> To use CredHub with Spring Cloud Services, you must be using Pivotal Application Service (PAS) 2.0 or later, have <a href="https://docs.pivotal.io/pivotalcf/opsguide/secure-si-creds.html">configured the Runtime CredHub</a>, and have at least one CredHub job instance configured in the PAS tile's Resource Config settings tab.</p>
 
 <%= image_tag("/spring-cloud-services/images/operator-information/secure-si-credentials.png") %>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://proxy1.com (200) with 2 occurrences could not be migrated:  
   ([https](https://proxy1.com) result SSLException).
* [ ] http://proxy2.com (200) with 1 occurrences could not be migrated:  
   ([https](https://proxy2.com) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://cookie.apps.wise.com/actuator/env (UnknownHostException) with 1 occurrences migrated to:  
  https://cookie.apps.wise.com/actuator/env ([https](https://cookie.apps.wise.com/actuator/env) result UnknownHostException).
* [ ] http://cookie.apps.wise.com/actuator/refresh (UnknownHostException) with 1 occurrences migrated to:  
  https://cookie.apps.wise.com/actuator/refresh ([https](https://cookie.apps.wise.com/actuator/refresh) result UnknownHostException).
* [ ] http://cookie.apps.wise.com/restaurant (UnknownHostException) with 2 occurrences migrated to:  
  https://cookie.apps.wise.com/restaurant ([https](https://cookie.apps.wise.com/restaurant) result UnknownHostException).
* [ ] http://example.com/config (404) with 1 occurrences migrated to:  
  https://example.com/config ([https](https://example.com/config) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html ([https](https://cloud.spring.io/spring-cloud-config/spring-cloud-config.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-cloud-foundry-connector.html) result 200).
* [ ] http://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html ([https](https://cloud.spring.io/spring-cloud-connectors/spring-cloud-connectors.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 5 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Value.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Value.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/annotation/Value.html) result 200).
* [ ] http://network.pivotal.io with 1 occurrences migrated to:  
  https://network.pivotal.io ([https](https://network.pivotal.io) result 200).
* [ ] http://projects.spring.io/spring-security/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-security/ ([https](https://projects.spring.io/spring-security/) result 200).
* [ ] http://docs.pivotal.io/pivotalcf/opsguide/secure-si-creds.html with 1 occurrences migrated to:  
  https://docs.pivotal.io/pivotalcf/opsguide/secure-si-creds.html ([https](https://docs.pivotal.io/pivotalcf/opsguide/secure-si-creds.html) result 301).