### PR TITLE
Fixes in v3.0 documentation

### DIFF
--- a/actuator-endpoints.html.md.erb
+++ b/actuator-endpoints.html.md.erb
@@ -60,7 +60,7 @@ $ curl -H "Authorization: $(cf oauth-token)" https://scs-service-broker.sys.exam
 
 ## <a id="service-instance-endpoints"></a>Service Instance Endpoints
 
-A Config Server service instance's backing Spring Cloud Config Server app enables the Spring Boot Actuator `health` and `info` endpoints. See below for information about how to access these endpoints.
+A Config Server service instance's backing Spring Cloud Config Server app enables the Spring Boot Actuator `health` endpoint. See below for information about how to access it.
 
 ### <a id="locating-service-instance-url"></a>Locating the Service Instance URL
 

--- a/common/config-server/configuring-with-git.html.md.erb
+++ b/common/config-server/configuring-with-git.html.md.erb
@@ -52,6 +52,10 @@ Parameters used to configure configuration sources are part of a JSON object cal
 		<td><code>skipSslValidation</code></td>
     <td>For a <code>https://</code> URI, whether to skip validation of the SSL certificate on the repository's server. Valid values: <code>true</code>, <code>false</code></td>
 	</tr>
+	<tr>
+		<td><code>cloneOnStart</code></td>
+    <td>Whether the Config Server should clone the default repository when it starts up (by default, the Config Server will only clone the repository when configuration is first requested from the repository). Valid values: <code>true</code>, <code>false</code></td>
+	</tr>
 </table>
 
 You can set `label` to a branch name, a tag name, or a specific Git commit hash. To set `label` to point to the `develop` branch of a repository, you might configure settings as in the following:


### PR DESCRIPTION
- `info` endpoint is not accessible for the service instance in v3.0.
- `cloneOnStart` parameter has been added to Git configuration